### PR TITLE
Add quotes to fix path interp issue

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -24,7 +24,7 @@ echo "Setting up vim-plug"
 BUNDLE_DIR=~/.vim/autoload
 
 rm -rf "$BUNDLE_DIR/*"
-mkdir -p $BUNDLE_DIR
+mkdir -p "$BUNDLE_DIR"
 
 curl -fLo ~/.vim/autoload/plug.vim --create-dirs https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
 


### PR DESCRIPTION
By not having quotes around $BUNDLE_DIR you accidentally shorten the path's interpretation from:

~/.vim/autoload

to

~/.vim

Not sure why Bash does this. Of course, then, the files go in .vim and not autoload:
![image](https://user-images.githubusercontent.com/17126217/82162149-edfc2680-9867-11ea-952a-52076f493ec2.png)

This PR fixes this issue:
![image](https://user-images.githubusercontent.com/17126217/82162170-0f5d1280-9868-11ea-8e68-3b1ea3ccb89f.png)
